### PR TITLE
[WIP].gitignoreを編集

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+public/uploads/*


### PR DESCRIPTION
#What
カリキュラムに沿って

#Why
あらかじめ画像が保管されるpublic/uploadsディレクトリを.gitignoreに追加しておき、画像がGithubにコミットされないようにするため